### PR TITLE
Modify cTakes pipeline to include section detection

### DIFF
--- a/data/mednotes/BsvSegmentAnnotator.xml
+++ b/data/mednotes/BsvSegmentAnnotator.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<taeDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+  <primitive>true</primitive>
+  <annotatorImplementationName>org.apache.ctakes.core.ae.BsvRegexSectionizer</annotatorImplementationName>
+  <analysisEngineMetaData>
+    <name>BsvRegexSectionizer</name>
+    <description>Creates a single Segment annotation, encompassing the entire document.  For use prior to annotators that require a Segment annotation, when the input document is not in CDA/does not have another annotator that creates Segment annotations.</description>
+    <version>2.2</version>
+    <vendor>Mayo Clinic</vendor>
+    <configurationParameters>
+      <configurationParameter>
+        <name>SectionsBsv</name>
+        <description/>
+        <type>String</type>
+        <multiValued>false</multiValued>
+        <mandatory>false</mandatory>
+      </configurationParameter>
+    </configurationParameters>
+    <configurationParameterSettings>
+      <nameValuePair>
+        <name>SectionsBsv</name>
+        <value>
+          <string>org/apache/ctakes/core/sections/DefaultSectionRegex.bsv</string>
+        </value>
+      </nameValuePair>
+    </configurationParameterSettings>
+    <typeSystemDescription>
+      <imports>
+        <import name="org.apache.ctakes.typesystem.types.TypeSystem"/>
+      </imports>
+    </typeSystemDescription>
+    <typePriorities/>
+    <fsIndexCollection/>
+    <capabilities>
+      <capability>
+        <inputs/>
+        <outputs>
+          <type allAnnotatorFeatures="true">org.apache.ctakes.typesystem.type.textspan.Segment</type>
+        </outputs>
+        <languagesSupported/>
+      </capability>
+    </capabilities>
+    <operationalProperties>
+      <modifiesCas>true</modifiesCas>
+      <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+      <outputsNewCASes>false</outputsNewCASes>
+    </operationalProperties>
+  </analysisEngineMetaData>
+</taeDescription>

--- a/data/mednotes/cTakes_CLI.xml
+++ b/data/mednotes/cTakes_CLI.xml
@@ -40,7 +40,7 @@
                   </value>
               </nameValuePair>
           </configurationParameterSettings>
-		      <deploymentParameters/>
+          <deploymentParameters/>
           <errorHandling>
               <errorRateThreshold action="terminate" value="0/1000"/>
               <maxConsecutiveRestarts action="terminate" value="30"/>

--- a/data/mednotes/cTakes_CLI.xml
+++ b/data/mednotes/cTakes_CLI.xml
@@ -16,38 +16,58 @@
         </collectionIterator>
     </collectionReader>
     <casProcessors casPoolSize="3" processingUnitThreadCount="1">
-    <casProcessor deployment="integrated" name="AggregatePlaintextUMLSProcessor">
-        <descriptor>
-            <import location="../desc/ctakes-clinical-pipeline/desc/analysis_engine/AggregatePlaintextUMLSProcessor.xml"/>
-        </descriptor>
-            <deploymentParameters/>
-        <errorHandling>
-            <errorRateThreshold action="terminate" value="0/1000"/>
-            <maxConsecutiveRestarts action="terminate" value="30"/>
-            <timeout max="100000" default="-1"/>
-        </errorHandling>
-        <checkpoint batch="10000" time="1000ms"/>
-    </casProcessor>
-    <casProcessor deployment="integrated" name="Write CAS to XML file">
-        <descriptor>
-            <import location="../desc/ctakes-core/desc/cas_consumer/FileWriterCasConsumer.xml"/>
-        </descriptor>
-            <deploymentParameters/>
-        <errorHandling>
-            <errorRateThreshold action="terminate" value="0/1000"/>
-            <maxConsecutiveRestarts action="terminate" value="30"/>
-            <timeout max="100000" default="-1"/>
-        </errorHandling>
-        <checkpoint batch="10000" time="1000ms"/>
-        <configurationParameterSettings>
-            <nameValuePair>
-                <name>outputDir</name>
-                <value>
-                    <string>C:\temp\MedNotes\output_cTakes_xml</string>
-                </value>
-            </nameValuePair>
-        </configurationParameterSettings>
-    </casProcessor>
+      <casProcessor deployment="integrated" name="SecionSplitter">
+          <descriptor>
+              <import location="../desc/ctakes-clinical-pipeline/desc/analysis_engine/AggregatePlaintextUMLSProcessor.xml"/>
+          </descriptor>
+		      <deploymentParameters/>
+          <errorHandling>
+              <errorRateThreshold action="terminate" value="0/1000"/>
+              <maxConsecutiveRestarts action="terminate" value="30"/>
+              <timeout max="100000" default="-1"/>
+          </errorHandling>
+          <checkpoint batch="10000" time="1000ms"/>
+      </casProcessor>
+      <casProcessor deployment="integrated" name="ConditionDetection">
+          <descriptor>
+              <import location="./BsvSegmentAnnotator.xml"/>
+          </descriptor>
+          <configurationParameterSettings>
+              <nameValuePair>
+                  <name>SectionsBsv</name>
+                  <value>
+                      <string>org/apache/ctakes/core/sections/DefaultSectionRegex.bsv</string>
+                  </value>
+              </nameValuePair>
+          </configurationParameterSettings>
+		      <deploymentParameters/>
+          <errorHandling>
+              <errorRateThreshold action="terminate" value="0/1000"/>
+              <maxConsecutiveRestarts action="terminate" value="30"/>
+              <timeout max="100000" default="-1"/>
+          </errorHandling>
+          <checkpoint batch="10000" time="1000ms"/>
+      </casProcessor>
+      <casProcessor deployment="integrated" name="Write CAS to XML file">
+          <descriptor>
+              <import location="../desc/ctakes-core/desc/cas_consumer/FileWriterCasConsumer.xml"/>
+          </descriptor>
+              <deploymentParameters/>
+          <errorHandling>
+              <errorRateThreshold action="terminate" value="0/1000"/>
+              <maxConsecutiveRestarts action="terminate" value="30"/>
+              <timeout max="100000" default="-1"/>
+          </errorHandling>
+          <checkpoint batch="10000" time="1000ms"/>
+          <configurationParameterSettings>
+              <nameValuePair>
+                  <name>outputDir</name>
+                  <value>
+                      <string>C:\temp\MedNotes\output_cTakes_xml</string>
+                  </value>
+              </nameValuePair>
+          </configurationParameterSettings>
+      </casProcessor>
     </casProcessors>
     <cpeConfig>
         <numToProcess>-1</numToProcess>

--- a/data/mednotes/cTakes_CLI.xml
+++ b/data/mednotes/cTakes_CLI.xml
@@ -16,7 +16,7 @@
         </collectionIterator>
     </collectionReader>
     <casProcessors casPoolSize="3" processingUnitThreadCount="1">
-      <casProcessor deployment="integrated" name="SecionSplitter">
+      <casProcessor deployment="integrated" name="AggregatePlaintextUMLSProcessor">
           <descriptor>
               <import location="../desc/ctakes-clinical-pipeline/desc/analysis_engine/AggregatePlaintextUMLSProcessor.xml"/>
           </descriptor>
@@ -28,7 +28,7 @@
           </errorHandling>
           <checkpoint batch="10000" time="1000ms"/>
       </casProcessor>
-      <casProcessor deployment="integrated" name="ConditionDetection">
+      <casProcessor deployment="integrated" name="SecionSplitter">
           <descriptor>
               <import location="./BsvSegmentAnnotator.xml"/>
           </descriptor>


### PR DESCRIPTION
Added the pipeline step, based on cTakes standard `BsvRegexSectionizer` from `ctakes-core`.

This results in addition `Segment` annotation appearing in the CAS

```

    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="15" _ref_sofa="3" begin="0" end="9497" id="SIMPLE_SEGMENT" preferredText="SIMPLE_SEGMENT"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155138" _ref_sofa="3" begin="0" end="296" id="SIMPLE_SEGMENT" preferredText="SIMPLE_SEGMENT"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155145" _ref_sofa="3" begin="312" end="385" id="Chief Complaint" preferredText="Chief Complaint" tagText="Chief Complaint&#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155152" _ref_sofa="3" begin="414" end="3736" id="History of Present Illness" preferredText="History of Present Illness" tagText="History of Present Illness:&#13;&#10;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155159" _ref_sofa="3" begin="3757" end="3758" id="Past Medical History" preferredText="Past Medical History" tagText="Past Medical History:"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155166" _ref_sofa="3" begin="3768" end="3775" id="Diagnosis" preferredText="Diagnosis" tagText="Diagnosis&#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155173" _ref_sofa="3" begin="3791" end="3877" id="Substance Abuse Treatment" preferredText="Substance Abuse Treatment" tagText="Alcohol abuse&#13; &#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155180" _ref_sofa="3" begin="3892" end="4386" id="Substance Abuse Treatment" preferredText="Substance Abuse Treatment" tagText="Drug abuse&#13; &#13; &#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155187" _ref_sofa="3" begin="4402" end="4407" id="Past Surgical History" preferredText="Past Surgical History" tagText="Surgical History"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155194" _ref_sofa="3" begin="4430" end="4532" id="Past Surgical History" preferredText="Past Surgical History" tagText="Past Surgical History:&#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155201" _ref_sofa="3" begin="4546" end="4547" id="Patient History" preferredText="Patient History" tagText="Social History"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155208" _ref_sofa="3" begin="4561" end="4569" id="Patient History" preferredText="Patient History" tagText="Social History"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155215" _ref_sofa="3" begin="4584" end="4947" id="Patient History" preferredText="Patient History" tagText="Social History&#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155222" _ref_sofa="3" begin="4959" end="5450" id="Ethanol Use" preferredText="Ethanol Use" tagText="Alcohol use&#13;"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155229" _ref_sofa="3" begin="5456" end="5465" id="Treatment Goals" preferredText="Treatment Goals" tagText="Goals:"/>
    <org.apache.ctakes.typesystem.type.textspan.Segment _indexed="1" _id="155236" _ref_sofa="3" begin="5490" end="9497" id="Treatment Goals" preferredText="Treatment Goals" tagText="Goals &#13;&#13;&#13;&#13;&#13;&#13;&#13;&#13;&#13; &#13;&#13;&#13;&#13;&#13;&#13;&#13; &#13;"/>
```

Take notice that there two Segments with `SIMPLE_SEGMENT` name. First one which cover whole document is added by the `AggregatePlaintextUMLSProcessor`. Second one is created by the `BsvRegexSectionizer` and cover text before first section appears.
